### PR TITLE
docs: fix typo in docs/source/errors.rst

### DIFF
--- a/docs/source/errors.rst
+++ b/docs/source/errors.rst
@@ -18,7 +18,7 @@ follows:
 Functions
 ---------
 
-Functions taking two arguments provide sensible pre-formated error messages.
+Functions taking two arguments provide sensible pre-formatted error messages.
 
 .. code:: c++
 


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `docs/source/errors.rst`



Ciao! :robot: