### PR TITLE
Update gh-action-sigstore-python workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         path: dist
         merge-multiple: true
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.0
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         password: ${{ secrets.pypi_password }}
         inputs: >-


### PR DESCRIPTION
- the old workflow used and outdated version of upload-artifacts
- also add depandabot to allow auto-update of actions

I had noticed that the signing failed and no GH release was created therefore. 
The reason was that GH actions no longer supports the outdated version of `upload-artifact` that was used by the also outdated version of ` gh-action-sigstore-python`.
The added `dependabot` will create PRs to update outdated actions once per month.

I did not add a release note as this is an infrastructure change only.